### PR TITLE
Added array filter test and handle for multiple values

### DIFF
--- a/src/Plugin/Tamper/ArrayFilter.php
+++ b/src/Plugin/Tamper/ArrayFilter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\tamper\Plugin\Tamper;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tamper\TamperBase;
+
+/**
+ * Plugin implementation for filtering data.
+ *
+ * @Tamper(
+ *   id = "array_filter",
+ *   label = @Translation("Filter items"),
+ *   description = @Translation("Filter empty items from a list."),
+ *   category = "List"
+ * )
+ */
+class ArrayFilter extends TamperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return $form;
+  }
+
+  /**
+   * Returns a short summary for the current tamper settings.
+   *
+   * If an empty result is returned, a UI can still be provided to display
+   * a settings form in case the tamper has configurable settings.
+   *
+   * @return string[]
+   *   A short summary of the tamper settings.
+   */
+  public function settingsSummary() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tamperMultipleValues($data) {
+    return array_values(array_filter($data));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tamperSingleValue($data) {
+    // Convert to an array so that the plugin can handle this.
+    return $this->tamperMultipleValues([$data]);
+  }
+
+}

--- a/src/Plugin/Tamper/Explode.php
+++ b/src/Plugin/Tamper/Explode.php
@@ -34,8 +34,6 @@ class Explode extends TamperBase {
    * {@inheritdoc}
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
-    $form = parent::settingsForm($form, $form_state);
-
     $form[self::SETTING_SEPARATOR] = array(
       '#type' => 'textfield',
       '#title' => $this->t('String separator'),
@@ -65,7 +63,7 @@ class Explode extends TamperBase {
    * {@inheritdoc}
    */
   public function settingsSummary() {
-    $summary = parent::settingsSummary();
+    $summary = [];
     if ($this->getSetting(self::SETTING_SEPARATOR)) {
       $summary[] = $this->t('Separating data using @separator', ['@separator' => $this->getSetting(self::SETTING_SEPARATOR)]);
     }
@@ -78,7 +76,7 @@ class Explode extends TamperBase {
   /**
    * {@inheritdoc}
    */
-  public function tamper($data) {
+  public function tamperSingleValue($data) {
     $separator = str_replace(array('%s', '%t', '%n'), array(' ', "\t", "\n"), $this->getSetting(self::SETTING_SEPARATOR));
     $limit = is_numeric($this->getSetting(self::SETTING_LIMIT)) ? $this->getSetting(self::SETTING_LIMIT) : PHP_INT_MAX;
     return explode($separator, $data, $limit);

--- a/src/TamperBase.php
+++ b/src/TamperBase.php
@@ -26,9 +26,30 @@ abstract class TamperBase extends PluginBase implements TamperInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Tamper data.
+   *
+   * Performs the operations on a single value instance of data to transform it.
+   *
+   * @param mixed $data
+   *   The data to tamper.
+   *
+   * @return mixed
+   *   The tampered data.
    */
-  public function tamperMultipleValues($data) {
+  abstract protected function tamperSingleValue($data);
+
+  /**
+   * Tamper data.
+   *
+   * Performs the operations on multiple value data to transform it.
+   *
+   * @param array $data
+   *   The data to tamper.
+   *
+   * @return mixed
+   *   The tampered data.
+   */
+  protected function tamperMultipleValues($data) {
     return array_map([$this, 'tamperSingleValue'], $data);
   }
 

--- a/src/TamperBase.php
+++ b/src/TamperBase.php
@@ -5,6 +5,9 @@ namespace Drupal\tamper;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Plugin\PluginBase;
 
+/**
+ * Provides a base class to tamper data from.
+ */
 abstract class TamperBase extends PluginBase implements TamperInterface {
 
   /**
@@ -13,6 +16,20 @@ abstract class TamperBase extends PluginBase implements TamperInterface {
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->setConfiguration($configuration);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tamper($data) {
+    return is_array($data) ? $this->tamperMultipleValues($data) : $this->tamperSingleValue($data);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tamperMultipleValues($data) {
+    return array_map([$this, 'tamperSingleValue'], $data);
   }
 
   /**

--- a/src/TamperInterface.php
+++ b/src/TamperInterface.php
@@ -49,29 +49,4 @@ interface TamperInterface extends ConfigurablePluginInterface {
    */
   public function tamper($data);
 
-  /**
-   * Tamper data.
-   *
-   * Performs the operations on a singe instance of data to transform it.
-   *
-   * @param mixed $data
-   *   The data to tamper.
-   *
-   * @return mixed
-   *   The tampered data.
-   */
-  public function tamperSingleValue($data);
-
-  /**
-   * Tamper data.
-   *
-   * Performs the operations on multiple instances of data to transform it.
-   *
-   * @param array $data
-   *   The data to tamper.
-   *
-   * @return mixed
-   *   The tampered data.
-   */
-  public function tamperMultipleValues($data);
 }

--- a/src/TamperInterface.php
+++ b/src/TamperInterface.php
@@ -41,8 +41,6 @@ interface TamperInterface extends ConfigurablePluginInterface {
    *
    * Performs the operations on the data to transform it.
    *
-   * @todo: Can we avoid generic param and return types?
-   *
    * @param mixed $data
    *   The data to tamper.
    *
@@ -50,4 +48,30 @@ interface TamperInterface extends ConfigurablePluginInterface {
    *   The tampered data.
    */
   public function tamper($data);
+
+  /**
+   * Tamper data.
+   *
+   * Performs the operations on a singe instance of data to transform it.
+   *
+   * @param mixed $data
+   *   The data to tamper.
+   *
+   * @return mixed
+   *   The tampered data.
+   */
+  public function tamperSingleValue($data);
+
+  /**
+   * Tamper data.
+   *
+   * Performs the operations on multiple instances of data to transform it.
+   *
+   * @param array $data
+   *   The data to tamper.
+   *
+   * @return mixed
+   *   The tampered data.
+   */
+  public function tamperMultipleValues($data);
 }

--- a/tests/src/Unit/Plugin/Tamper/ArrayFilterTest.php
+++ b/tests/src/Unit/Plugin/Tamper/ArrayFilterTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Tests\tamper\Unit\Plugin\Tamper;
+
+use Drupal\tamper\Plugin\Tamper\ArrayFilter;
+use Drupal\Tests\UnitTestCase;
+
+class ExplodeTest extends UnitTestCase {
+
+  public function testArrayFilter() {
+    $config = [];
+    $plugin = new ArrayFilter($config, 'array_filter', []);
+    $this->assertArrayEquals(['foo','bar','baz','zip'], $plugin->tamper(['foo','','bar',FALSE,'baz',[],'zip']));
+  }
+
+}

--- a/tests/src/Unit/Plugin/Tamper/ArrayFilterTest.php
+++ b/tests/src/Unit/Plugin/Tamper/ArrayFilterTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\tamper\Unit\Plugin\Tamper;
 use Drupal\tamper\Plugin\Tamper\ArrayFilter;
 use Drupal\Tests\UnitTestCase;
 
-class ExplodeTest extends UnitTestCase {
+class ArrayFilterTest extends UnitTestCase {
 
   public function testArrayFilter() {
     $config = [];


### PR DESCRIPTION
Just exploring how arrays should be handled.

This idea is to make array vs single value handling compulsory for each plugin.

I assume most plugins would just loop through an array and apply the same logic each time, where as there are a couple of feeds tamper plugins that work exclusively on arrays. 

If we are going to be in a situation where we are calling the generic tamper method in a chain with no checks for if we are dealing with an array or not, I would argue that handling of the value being an array or not is pretty core to the requirement of a tamper plugin - given we are allowing for an input and output of essentially anything.