### PR TITLE
by MegaChriz: fixed one typo in Tamper annotation class.

### DIFF
--- a/src/Annotation/Tamper.php
+++ b/src/Annotation/Tamper.php
@@ -42,7 +42,7 @@ class Tamper extends Plugin {
   public $description;
 
   /**
-   * The category under which the field type should be listed in the UI.
+   * The category under which the tamper plugin should be listed in the UI.
    *
    * @var \Drupal\Core\Annotation\Translation
    *


### PR DESCRIPTION
I discovered just a small typo in src/Annotation/Tamper.php. The documentation for `public $category` references 'field type', while this should be 'tamper plugin'.